### PR TITLE
PY3: handle cookies as bytes

### DIFF
--- a/testspiders/spiders/followall.py
+++ b/testspiders/spiders/followall.py
@@ -63,7 +63,7 @@ class FollowAllSpider(scrapy.Spider):
 
     def _set_new_cookies(self, page, response):
         cookies = []
-        for cookie in [x.split(';', 1)[0] for x in
+        for cookie in [x.split(b';', 1)[0] for x in
                        response.headers.getlist('Set-Cookie')]:
             if cookie not in self.cookies_seen:
                 self.cookies_seen.add(cookie)


### PR DESCRIPTION
I was getting these:

```
2016-02-15 13:36:27 [scrapy] ERROR: Spider error processing <GET http://support.scrapinghub.com/> (referer: http://scrapinghub.com/)
Traceback (most recent call last):
  File "/home/paul/.virtualenvs/scrapy3rc1/lib/python3.4/site-packages/twisted/internet/defer.py", line 588, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/paul/src/testspiders/testspiders/spiders/followall.py", line 36, in parse
    page = self._get_item(response)
  File "/home/paul/src/testspiders/testspiders/spiders/followall.py", line 48, in _get_item
    self._set_new_cookies(item, response)
  File "/home/paul/src/testspiders/testspiders/spiders/followall.py", line 67, in _set_new_cookies
    response.headers.getlist('Set-Cookie')]:
  File "/home/paul/src/testspiders/testspiders/spiders/followall.py", line 66, in <listcomp>
    for cookie in [x.split(';', 1)[0] for x in
TypeError: 'str' does not support the buffer interface
```