### PR TITLE
Move reactor imports away from the top of files

### DIFF
--- a/testspiders/spiders/timed.py
+++ b/testspiders/spiders/timed.py
@@ -2,7 +2,6 @@
 Crawll-all spider without domain restriction
 """
 from testspiders.spiders.followall import FollowAllSpider
-from twisted.internet import reactor
 
 
 class TimedSpider(FollowAllSpider):
@@ -15,6 +14,7 @@ class TimedSpider(FollowAllSpider):
         super(TimedSpider, self).__init__(**kw)
 
     def start_requests(self):
+        from twisted.internet import reactor
         reactor.callLater(self.timeout, self.stop)
         return super(TimedSpider, self).start_requests()
 

--- a/testspiders/spiders/timewaste.py
+++ b/testspiders/spiders/timewaste.py
@@ -1,5 +1,4 @@
 import scrapy
-from twisted.internet import reactor, defer
 
 
 class Spider(scrapy.Spider):
@@ -11,6 +10,7 @@ class Spider(scrapy.Spider):
         super(Spider, self).__init__(**kw)
 
     def parse(self, response):
+        from twisted.internet import reactor, defer
         self.log('I will waste your time for {} seconds'.format(self.timeout))
         dfd = defer.Deferred()
         reactor.callLater(self.timeout, dfd.callback, None)


### PR DESCRIPTION
While working on updating https://github.com/scrapy/scrapy/pull/1455 (after the introduction of the `ASYNCIO_REACTOR` setting in https://github.com/scrapy/scrapy/pull/4010 there is no need to install the `asyncio` reactor as a monkeypatch) I found that the example command in the former was crashing because these two spiders were importing the (default) reactor at the top of their files, preventing Scrapy to install the `asyncio` one.